### PR TITLE
Fix: preserve name on @Process

### DIFF
--- a/lib/app-startup.ts
+++ b/lib/app-startup.ts
@@ -1,6 +1,3 @@
-import { statSync } from "node:fs";
-import { mkdir, readdir } from "node:fs/promises";
-import { basename, extname, join, resolve } from "node:path";
 import { cors } from "@elysiajs/cors";
 import { html } from "@elysiajs/html";
 import jwt from "@elysiajs/jwt";
@@ -9,6 +6,7 @@ import { swagger } from "@elysiajs/swagger";
 import { type Job, Worker } from "bullmq";
 import Elysia from "elysia";
 import scheduler from "node-cron";
+import { mkdir } from "node:fs/promises";
 import React from "react";
 import { renderToReadableStream } from "react-dom/server";
 import "reflect-metadata";
@@ -44,7 +42,6 @@ import { RateLimitService } from "./ratelimit/ratelimit.service";
 import { RENDER_METADATA } from "./render";
 import type { Options, RateLimitGlobalConfig } from "./types/options";
 import { Bundler } from "./utils/bundler";
-import { cwd } from "./utils/cwd";
 import {
 	GlobalRegistry,
 	resolveDependencies,
@@ -373,10 +370,28 @@ export class AppStartup {
 		AppStartup.registerTimeouts(module);
 		AppStartup.registerCronJobs(module);
 		AppStartup.registerBullMqWorkers(module);
-		AppStartup.registerCqrsHandlers(module);
 		AppStartup.registerRabbitMQConsumers(module);
 
 		const modules = Reflect.getMetadata("dip:modules", module) || [];
+
+		// Pre-register global sub-modules so their injectables (e.g. CqrsModule buses)
+		// are available in GlobalRegistry before CQRS handlers are registered
+		for (const mod of modules) {
+			const modIsGlobal = Reflect.getMetadata("dip:module:global", mod);
+			if (modIsGlobal) {
+				const modInjectables: Map<any, any> | undefined = Reflect.getMetadata(
+					"dip:injectables",
+					mod,
+				);
+				if (modInjectables) {
+					for (const [key, value] of modInjectables.entries()) {
+						GlobalRegistry.register(key, value);
+					}
+				}
+			}
+		}
+
+		AppStartup.registerCqrsHandlers(module);
 
 		for (const mod of modules) {
 			await AppStartup.registerModules(mod);
@@ -1135,9 +1150,10 @@ export class AppStartup {
 
 		if (!injectables) return;
 
-		const commandBus = injectables.get(CommandBus);
-		const queryBus = injectables.get(QueryBus);
-		const eventBus = injectables.get(EventBus);
+		const commandBus =
+			injectables.get(CommandBus) || GlobalRegistry.get(CommandBus);
+		const queryBus = injectables.get(QueryBus) || GlobalRegistry.get(QueryBus);
+		const eventBus = injectables.get(EventBus) || GlobalRegistry.get(EventBus);
 
 		const commandHandlers: any[] = [];
 		const queryHandlers: any[] = [];

--- a/lib/cqrs/command-bus.ts
+++ b/lib/cqrs/command-bus.ts
@@ -34,10 +34,33 @@ export class CommandBus {
 	 */
 	async execute<T extends ICommand, R = any>(command: T): Promise<R> {
 		const commandType = command.constructor;
-		const handler = this.handlers.get(commandType);
+		const handler = this.getHandler(commandType);
 		if (!handler) {
 			throw CqrsError.noCommandHandler(commandType.name);
 		}
 		return handler.execute(command);
+	}
+
+	private getHandler(commandType: any): ICommandHandler | undefined {
+		const exactHandler = this.handlers.get(commandType);
+		if (exactHandler) {
+			return exactHandler;
+		}
+
+		if (typeof commandType !== "function" || !commandType.name) {
+			return undefined;
+		}
+
+		let matchedHandler: ICommandHandler | undefined;
+		for (const [registeredType, handler] of this.handlers.entries()) {
+			if (
+				typeof registeredType === "function" &&
+				registeredType.name === commandType.name
+			) {
+				matchedHandler = handler;
+			}
+		}
+
+		return matchedHandler;
 	}
 }

--- a/lib/cqrs/event-bus.ts
+++ b/lib/cqrs/event-bus.ts
@@ -69,7 +69,7 @@ export class EventBus {
 	 */
 	publish<T extends IEvent>(event: T): void {
 		const eventType = event.constructor;
-		const handlers = this.handlers.get(eventType) || [];
+		const handlers = this.getHandlers(eventType);
 		handlers.forEach((handler) => {
 			handler.handle(event);
 		});
@@ -88,6 +88,33 @@ export class EventBus {
 		return new EventStream((callback) => {
 			this.listeners.push(callback);
 		});
+	}
+
+	private getHandlers(eventType: any): IEventHandler[] {
+		const exactHandlers = this.handlers.get(eventType);
+		if (exactHandlers) {
+			return exactHandlers;
+		}
+
+		if (typeof eventType !== "function" || !eventType.name) {
+			return [];
+		}
+
+		const matchedHandlers: IEventHandler[] = [];
+		for (const [registeredType, handlers] of this.handlers.entries()) {
+			if (
+				typeof registeredType === "function" &&
+				registeredType.name === eventType.name
+			) {
+				for (const handler of handlers) {
+					if (!matchedHandlers.includes(handler)) {
+						matchedHandlers.push(handler);
+					}
+				}
+			}
+		}
+
+		return matchedHandlers;
 	}
 }
 

--- a/lib/cqrs/query-bus.ts
+++ b/lib/cqrs/query-bus.ts
@@ -34,10 +34,33 @@ export class QueryBus {
 	 */
 	async execute<T extends IQuery, R = any>(query: T): Promise<R> {
 		const queryType = query.constructor;
-		const handler = this.handlers.get(queryType);
+		const handler = this.getHandler(queryType);
 		if (!handler) {
 			throw CqrsError.noQueryHandler(queryType.name);
 		}
 		return handler.execute(query);
+	}
+
+	private getHandler(queryType: any): IQueryHandler | undefined {
+		const exactHandler = this.handlers.get(queryType);
+		if (exactHandler) {
+			return exactHandler;
+		}
+
+		if (typeof queryType !== "function" || !queryType.name) {
+			return undefined;
+		}
+
+		let matchedHandler: IQueryHandler | undefined;
+		for (const [registeredType, handler] of this.handlers.entries()) {
+			if (
+				typeof registeredType === "function" &&
+				registeredType.name === queryType.name
+			) {
+				matchedHandler = handler;
+			}
+		}
+
+		return matchedHandler;
 	}
 }

--- a/lib/utils/map-providers.ts
+++ b/lib/utils/map-providers.ts
@@ -14,7 +14,7 @@ export function mapProvidersWithType(
 ): Map<any, { expression?: string; delay?: number; methodName: string }[]> {
 	const result = new Map<
 		any,
-		{ expression?: string; delay?: number; methodName: string }[]
+		{ name?: string; expression?: string; delay?: number; methodName: string }[]
 	>();
 
 	for (const provider of providers) {
@@ -30,6 +30,7 @@ export function mapProvidersWithType(
 					}
 
 					result.get(provider)?.push({
+						name: method.name,
 						expression: method.expression,
 						delay: method.delay,
 						methodName: method.methodName,

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -22,8 +22,8 @@ import {
 	type IQueryHandler,
 	Jwt,
 	JwtModule,
-	Module,
 	map,
+	Module,
 	ofType,
 	Param,
 	Patch,
@@ -518,6 +518,40 @@ describe("Bunstone Framework Core", () => {
 
 			expect(cqrsService).toBeDefined();
 			expect(cqrsService.commandBus).toBeInstanceOf(CommandBus);
+		});
+
+		test("Handlers in sub-module without CqrsModule import should be registered via GlobalRegistry", async () => {
+			class SubModuleQuery {
+				constructor(public readonly value: string) {}
+			}
+
+			@QueryHandler(SubModuleQuery)
+			class SubModuleQueryHandler implements IQueryHandler<SubModuleQuery> {
+				async execute(query: SubModuleQuery) {
+					return `sub-result: ${query.value}`;
+				}
+			}
+
+			@Module({
+				providers: [SubModuleQueryHandler],
+			})
+			class SubFeatureModule {}
+
+			@Module({
+				imports: [CqrsModule, SubFeatureModule],
+			})
+			class SubCqrsRootModule {}
+
+			await AppStartup.create(SubCqrsRootModule);
+
+			const rootInjectables: Map<any, any> = Reflect.getMetadata(
+				"dip:injectables",
+				SubCqrsRootModule,
+			);
+			const queryBus: QueryBus = rootInjectables.get(QueryBus);
+
+			const result = await queryBus.execute(new SubModuleQuery("hello"));
+			expect(result).toBe("sub-result: hello");
 		});
 	});
 

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -553,6 +553,40 @@ describe("Bunstone Framework Core", () => {
 			const result = await queryBus.execute(new SubModuleQuery("hello"));
 			expect(result).toBe("sub-result: hello");
 		});
+
+		test("QueryBus should resolve handlers when the query reference differs but the class name matches", async () => {
+			const createQueryClass = () =>
+				class DuplicateQuery {
+					constructor(public readonly value: string) {}
+				};
+
+			const RegisteredQuery = createQueryClass();
+			const RuntimeQuery = createQueryClass();
+
+			@QueryHandler(RegisteredQuery)
+			class DuplicateQueryHandler implements IQueryHandler<any> {
+				async execute(query: any) {
+					return `duplicate-result: ${query.value}`;
+				}
+			}
+
+			@Module({
+				imports: [CqrsModule],
+				providers: [DuplicateQueryHandler],
+			})
+			class DuplicateQueryModule {}
+
+			await AppStartup.create(DuplicateQueryModule);
+
+			const injectables: Map<any, any> = Reflect.getMetadata(
+				"dip:injectables",
+				DuplicateQueryModule,
+			);
+			const queryBus: QueryBus = injectables.get(QueryBus);
+
+			const result = await queryBus.execute(new RuntimeQuery("hello"));
+			expect(result).toBe("duplicate-result: hello");
+		});
 	});
 
 	describe("Sagas", () => {


### PR DESCRIPTION
- Estava acontecendo um bug em que os jobs estavam sendo enviados para os `@Process` errados.
- Corrigido o mapeamento para preservar a propriedade `name` de `@Process`, garantindo que o handler seja registrado e casado corretamente com `job.name`.
- Correção de bug de `handler` sem `query` ou `command` mesmo estando registrados e importados corretamente.
