### PR TITLE
Fix: add support to set config bd

### DIFF
--- a/docs/database-sql.md
+++ b/docs/database-sql.md
@@ -43,6 +43,68 @@ OR using a connection string:
 export class AppModule {}
 ```
 
+### Connection options
+
+You can pass a second argument with pool and client settings. Bunstone forwards only the supported options to [Bun.SQL](https://bun.sh/docs/api/sql):
+
+```typescript
+@Module({
+  imports: [
+    SqlModule.register("mysql://user:pass@host:3306/db", {
+      maxLifetime: 25200,
+      connectionTimeout: 30,
+      max: 10,
+      timezone: "UTC",
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+The same options can be combined with the object-style registration:
+
+```typescript
+SqlModule.register({
+  provider: "postgresql",
+  host: "localhost",
+  port: 5432,
+  username: "user",
+  password: "password",
+  database: "my_db",
+  max: 20,
+  idleTimeout: 30,
+});
+```
+
+For backward compatibility, the second argument may still be a timezone string:
+
+```typescript
+SqlModule.register("mysql://user:pass@host/db", "UTC");
+```
+
+#### Supported options (`SqlModuleOptions`)
+
+| Option | Description |
+|---|---|
+| `timezone` | Bunstone helper for date/time handling. Defaults to `UTC`. Mapped to driver `connection` settings. |
+| `max` | Maximum connections in the pool |
+| `maxLifetime` | Maximum connection lifetime in seconds |
+| `connectionTimeout` | Timeout when establishing a connection (seconds) |
+| `idleTimeout` | Close idle connections after N seconds |
+| `connection` | Driver-specific runtime settings (e.g. PostgreSQL `TimeZone`) |
+| `tls` | TLS/SSL configuration |
+| `prepare` | Enable automatic prepared statements |
+| `bigint` | Return out-of-range integers as `BigInt` |
+| `onconnect` | Callback when a connection attempt completes |
+| `onclose` | Callback when a connection closes |
+| `path` | Unix domain socket path |
+| `readonly` | SQLite read-only mode |
+| `create` | SQLite create-if-missing behavior |
+| `safeIntegers` | SQLite safe integer handling |
+| `strict` | SQLite strict mode |
+
+Only the options listed above are accepted. Invalid keys are rejected by TypeScript and also throw `DatabaseError` (`BNS-DB-003`) at runtime.
+
 ## Usage
 
 Once registered, the `SqlService` is globally available. You can inject it into any controller or provider without needing to import `SqlModule` into subsequent modules.

--- a/docs/pt-BR/database-sql.md
+++ b/docs/pt-BR/database-sql.md
@@ -43,6 +43,68 @@ OU usando uma string de conexão:
 export class AppModule {}
 ```
 
+### Opções de conexão
+
+Você pode passar um segundo argumento com configurações de pool e do client. O Bunstone repassa apenas as opções suportadas para o [Bun.SQL](https://bun.sh/docs/api/sql):
+
+```typescript
+@Module({
+  imports: [
+    SqlModule.register("mysql://user:pass@host:3306/db", {
+      maxLifetime: 25200,
+      connectionTimeout: 30,
+      max: 10,
+      timezone: "UTC",
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+As mesmas opções podem ser usadas no registro via objeto:
+
+```typescript
+SqlModule.register({
+  provider: "postgresql",
+  host: "localhost",
+  port: 5432,
+  username: "user",
+  password: "password",
+  database: "my_db",
+  max: 20,
+  idleTimeout: 30,
+});
+```
+
+Por compatibilidade, o segundo argumento ainda pode ser uma string de timezone:
+
+```typescript
+SqlModule.register("mysql://user:pass@host/db", "UTC");
+```
+
+#### Opções suportadas (`SqlModuleOptions`)
+
+| Opção | Descrição |
+|---|---|
+| `timezone` | Helper do Bunstone para datas/horas. Padrão: `UTC`. Mapeado para `connection` do driver. |
+| `max` | Máximo de conexões no pool |
+| `maxLifetime` | Tempo máximo de vida da conexão em segundos |
+| `connectionTimeout` | Timeout ao estabelecer conexão (segundos) |
+| `idleTimeout` | Fecha conexões ociosas após N segundos |
+| `connection` | Configurações runtime do driver (ex.: `TimeZone` no PostgreSQL) |
+| `tls` | Configuração TLS/SSL |
+| `prepare` | Habilita prepared statements automáticos |
+| `bigint` | Retorna inteiros fora do range como `BigInt` |
+| `onconnect` | Callback ao concluir tentativa de conexão |
+| `onclose` | Callback ao fechar conexão |
+| `path` | Caminho do Unix domain socket |
+| `readonly` | Modo somente leitura (SQLite) |
+| `create` | Comportamento de criação do arquivo (SQLite) |
+| `safeIntegers` | Tratamento seguro de inteiros (SQLite) |
+| `strict` | Modo strict (SQLite) |
+
+Somente as opções listadas acima são aceitas. Chaves inválidas são rejeitadas pelo TypeScript e também lançam `DatabaseError` (`BNS-DB-003`) em runtime.
+
 ## Uso
 
 Depois de registrado, o `SqlService` fica disponível globalmente. Você pode injetá-lo em qualquer controller ou provider sem precisar importar o `SqlModule` nos módulos subsequentes.

--- a/index.ts
+++ b/index.ts
@@ -15,14 +15,15 @@ import "reflect-metadata";
  */
 
 export * from "./lib/adapters/cache-adapter";
-export { EmailModule, EmailService } from "./lib/email/email-module";
-export { EmailLayout } from "./lib/email/email-layout";
 export * from "./lib/adapters/form-data";
 export * from "./lib/adapters/upload-adapter";
 export * from "./lib/app-startup";
+export { BullMqModule } from "./lib/bullmq/bullmq-module";
+export * from "./lib/bullmq/decorators/process.decorator";
+export * from "./lib/bullmq/decorators/processor.decorator";
+export { QueueService } from "./lib/bullmq/queue.service";
 export * from "./lib/components/layout";
 export * from "./lib/controller";
-export * from "./lib/ratelimit";
 export * from "./lib/cqrs/command-bus";
 export * from "./lib/cqrs/cqrs-module";
 export * from "./lib/cqrs/decorators/command-handler.decorator";
@@ -35,44 +36,50 @@ export * from "./lib/cqrs/interfaces/event.interface";
 export * from "./lib/cqrs/interfaces/query.interface";
 export * from "./lib/cqrs/query-bus";
 export { SqlModule, SqlService } from "./lib/database/sql-module";
-export { BullMqModule } from "./lib/bullmq/bullmq-module";
-export { QueueService } from "./lib/bullmq/queue.service";
-export * from "./lib/bullmq/decorators/processor.decorator";
-export * from "./lib/bullmq/decorators/process.decorator";
-export { RabbitMQModule } from "./lib/rabbitmq/rabbitmq-module";
-export { RabbitMQService } from "./lib/rabbitmq/rabbitmq.service";
-export { RabbitMQDeadLetterService } from "./lib/rabbitmq/dead-letter.service";
-export { RabbitMQConnection } from "./lib/rabbitmq/rabbitmq-connection";
-export * from "./lib/rabbitmq/decorators/consumer.decorator";
-export * from "./lib/rabbitmq/decorators/subscribe.decorator";
-export type * from "./lib/rabbitmq/interfaces/rabbitmq-options.interface";
-export type * from "./lib/rabbitmq/interfaces/rabbitmq-message.interface";
+export type {
+	BunSqlClientOptions,
+	ConnectionOptions,
+	SqlConnectionDetails,
+	SqlModuleOptions,
+} from "./lib/database/sql-module";
+export { EmailLayout } from "./lib/email/email-layout";
+export { EmailModule, EmailService } from "./lib/email/email-module";
 export * from "./lib/errors";
-export { ErrorFormatter } from "./lib/utils/error-formatter";
 export * from "./lib/guard";
 export * from "./lib/http-exceptions";
 export * from "./lib/http-methods";
 export * from "./lib/http-params";
 export * from "./lib/injectable";
+export type { GuardContract } from "./lib/interfaces/guard-contract";
 export * from "./lib/jwt";
 export * from "./lib/jwt/jwt-module";
 export { JwtService } from "./lib/jwt/jwt.service";
 export * from "./lib/module";
 export * from "./lib/on-module";
 export * from "./lib/openapi";
+export { RabbitMQDeadLetterService } from "./lib/rabbitmq/dead-letter.service";
+export * from "./lib/rabbitmq/decorators/consumer.decorator";
+export * from "./lib/rabbitmq/decorators/subscribe.decorator";
+export type * from "./lib/rabbitmq/interfaces/rabbitmq-message.interface";
+export type * from "./lib/rabbitmq/interfaces/rabbitmq-options.interface";
+export { RabbitMQConnection } from "./lib/rabbitmq/rabbitmq-connection";
+export { RabbitMQModule } from "./lib/rabbitmq/rabbitmq-module";
+export { RabbitMQService } from "./lib/rabbitmq/rabbitmq.service";
+export * from "./lib/ratelimit";
 export * from "./lib/render";
-export * from "./lib/types/options";
-export * from "./lib/types/module-config";
 export * from "./lib/schedule/cron/cron";
 export * from "./lib/schedule/timeout/timeout";
+export type { OtlpExporterOptions, TelemetryOptions } from "./lib/telemetry/interfaces/telemetry-options.interface";
 export { TelemetryModule } from "./lib/telemetry/telemetry-module";
 export { TelemetrySdk } from "./lib/telemetry/telemetry.sdk";
-export type { TelemetryOptions, OtlpExporterOptions } from "./lib/telemetry/interfaces/telemetry-options.interface";
 export * from "./lib/testing/test";
-export * from "./lib/testing/testing-module";
 export * from "./lib/testing/test-app";
+export * from "./lib/testing/testing-module";
 export type { HttpRequest } from "./lib/types/http-request";
+export * from "./lib/types/module-config";
 export type { ModuleConfig } from "./lib/types/module-config";
+export * from "./lib/types/options";
 export type { Options } from "./lib/types/options";
+export { ErrorFormatter } from "./lib/utils/error-formatter";
 export * from "./lib/utils/logger";
-export type { GuardContract } from "./lib/interfaces/guard-contract";
+

--- a/index.ts
+++ b/index.ts
@@ -18,10 +18,10 @@ export * from "./lib/adapters/cache-adapter";
 export * from "./lib/adapters/form-data";
 export * from "./lib/adapters/upload-adapter";
 export * from "./lib/app-startup";
-export { BullMqModule, BullMqModule } from "./lib/bullmq/bullmq-module";
+export { BullMqModule } from "./lib/bullmq/bullmq-module";
 export * from "./lib/bullmq/decorators/process.decorator";
 export * from "./lib/bullmq/decorators/processor.decorator";
-export { QueueService, QueueService } from "./lib/bullmq/queue.service";
+export { QueueService } from "./lib/bullmq/queue.service";
 export * from "./lib/components/layout";
 export * from "./lib/controller";
 export * from "./lib/cqrs/command-bus";
@@ -37,10 +37,16 @@ export * from "./lib/cqrs/interfaces/query.interface";
 export * from "./lib/cqrs/query-bus";
 export { SqlModule, SqlService } from "./lib/database/sql-module";
 export type {
+	BunSqlClientOptions,
+	ConnectionOptions,
+	SqlConnectionDetails,
 	SqlConnectionOptions,
+	SqlModuleOptions,
 	SqlPoolOptions,
-	SqlRegisterOptions
+	SqlRegisterOptions,
 } from "./lib/database/sql-module";
+export { EmailLayout } from "./lib/email/email-layout";
+export { EmailModule, EmailService } from "./lib/email/email-module";
 export * from "./lib/errors";
 export * from "./lib/guard";
 export * from "./lib/http-exceptions";
@@ -54,14 +60,14 @@ export { JwtService } from "./lib/jwt/jwt.service";
 export * from "./lib/module";
 export * from "./lib/on-module";
 export * from "./lib/openapi";
-export { RabbitMQDeadLetterService, RabbitMQDeadLetterService } from "./lib/rabbitmq/dead-letter.service";
+export { RabbitMQDeadLetterService } from "./lib/rabbitmq/dead-letter.service";
 export * from "./lib/rabbitmq/decorators/consumer.decorator";
 export * from "./lib/rabbitmq/decorators/subscribe.decorator";
 export type * from "./lib/rabbitmq/interfaces/rabbitmq-message.interface";
 export type * from "./lib/rabbitmq/interfaces/rabbitmq-options.interface";
-export { RabbitMQConnection, RabbitMQConnection } from "./lib/rabbitmq/rabbitmq-connection";
-export { RabbitMQModule, RabbitMQModule } from "./lib/rabbitmq/rabbitmq-module";
-export { RabbitMQService, RabbitMQService } from "./lib/rabbitmq/rabbitmq.service";
+export { RabbitMQConnection } from "./lib/rabbitmq/rabbitmq-connection";
+export { RabbitMQModule } from "./lib/rabbitmq/rabbitmq-module";
+export { RabbitMQService } from "./lib/rabbitmq/rabbitmq.service";
 export * from "./lib/ratelimit";
 export * from "./lib/render";
 export * from "./lib/schedule/cron/cron";

--- a/lib/database/sql-module.ts
+++ b/lib/database/sql-module.ts
@@ -9,48 +9,133 @@ import { DatabaseError } from "../errors";
 import { Injectable } from "../injectable";
 import { Module } from "../module";
 
-export type SqlPoolOptions = {
-	/** Maximum connections in the pool. Bun default: 10 */
-	max?: number;
+type Provider = "postgresql" | "mysql" | "sqlite";
+
+type BunSqlPoolOptions = Pick<
+	SQL.PostgresOrMySQLOptions,
+	| "max"
+	| "maxLifetime"
+	| "connectionTimeout"
+	| "idleTimeout"
+	| "connection"
+	| "tls"
+	| "prepare"
+	| "bigint"
+	| "onconnect"
+	| "onclose"
+	| "path"
+>;
+
+type BunSqliteClientOptions = Pick<
+	SQL.SQLiteOptions,
+	"readonly" | "create" | "safeIntegers" | "strict"
+>;
+
+/** Options forwarded by Bunstone to the underlying Bun.SQL client. */
+export type BunSqlClientOptions = Partial<
+	BunSqlPoolOptions & BunSqliteClientOptions
+>;
+
+/**
+ * Options accepted by {@link SqlModule.register}.
+ * Only Bunstone-supported settings are allowed.
+ */
+export type SqlModuleOptions = BunSqlClientOptions & {
 	/**
-	 * Seconds before closing idle pool connections. Bun default: 0 (no limit).
-	 * For MariaDB/MySQL, set below the server `wait_timeout` (often 28800 = 8h).
+	 * Timezone used for date/time interpretation on the database connection.
+	 * Mapped to driver `connection` settings when not provided explicitly.
+	 * Defaults to `UTC`.
 	 */
-	idleTimeout?: number;
-	/**
-	 * Max connection lifetime in seconds. Bun default: 0 (no limit).
-	 * Forces periodic reconnection before the server drops stale sockets.
-	 */
-	maxLifetime?: number;
-	/** Seconds to wait when opening a new connection. Bun default: 30 */
-	connectionTimeout?: number;
+	timezone?: string;
 };
 
-export type SqlConnectionOptions = SqlPoolOptions & {
+export type SqlConnectionDetails = {
 	host: string;
 	port: number;
 	username: string;
 	password: string;
 	database: string;
-	provider: "postgresql" | "mysql" | "sqlite";
-	/**
-	 * Timezone used for date/time interpretation on the database connection.
-	 * Defaults to 'UTC' to ensure consistent, offset-free date handling.
-	 * Set to 'local' to use the process timezone, or any valid tz identifier.
-	 */
-	timezone?: string;
+	provider: Provider;
 };
 
-export type SqlRegisterOptions = SqlPoolOptions & {
-	timezone?: string;
-};
+export type ConnectionOptions = SqlConnectionDetails & SqlModuleOptions;
 
-type Provider = "postgresql" | "mysql" | "sqlite";
+/** @deprecated Use {@link ConnectionOptions} */
+export type SqlConnectionOptions = ConnectionOptions;
+
+/** @deprecated Use {@link SqlModuleOptions} */
+export type SqlRegisterOptions = SqlModuleOptions;
+
+/** Pool-related subset of {@link SqlModuleOptions}. */
+export type SqlPoolOptions = Pick<
+	SqlModuleOptions,
+	"max" | "maxLifetime" | "connectionTimeout" | "idleTimeout"
+>;
+
+type SqlClientInitOptions = Omit<
+	SqlModuleOptions,
+	"url" | "filename" | "timezone"
+>;
+
+const SQL_MODULE_OPTION_KEYS = [
+	"timezone",
+	"max",
+	"maxLifetime",
+	"connectionTimeout",
+	"idleTimeout",
+	"connection",
+	"tls",
+	"prepare",
+	"bigint",
+	"onconnect",
+	"onclose",
+	"path",
+	"readonly",
+	"create",
+	"safeIntegers",
+	"strict",
+] as const satisfies readonly (keyof SqlModuleOptions)[];
+
+const SQL_CONNECTION_DETAIL_KEYS = [
+	"host",
+	"port",
+	"username",
+	"password",
+	"database",
+	"provider",
+] as const satisfies readonly (keyof SqlConnectionDetails)[];
 
 const CONNECTION_CLOSED_CODES = new Set([
 	"ERR_MYSQL_CONNECTION_CLOSED",
 	"ERR_POSTGRES_CONNECTION_CLOSED",
 ]);
+
+function assertOnlyAllowedKeys(
+	source: Record<string, unknown>,
+	allowedKeys: readonly string[],
+): void {
+	const invalidKeys = Object.keys(source).filter(
+		(key) => !allowedKeys.includes(key),
+	);
+
+	if (invalidKeys.length > 0) {
+		throw DatabaseError.invalidConfig(invalidKeys, allowedKeys);
+	}
+}
+
+function pickSqlModuleOptions(
+	source: Record<string, unknown>,
+): SqlModuleOptions {
+	assertOnlyAllowedKeys(source, SQL_MODULE_OPTION_KEYS);
+
+	const picked = {} as SqlModuleOptions;
+	for (const key of SQL_MODULE_OPTION_KEYS) {
+		if (key in source) {
+			(picked as Record<string, unknown>)[key] = source[key];
+		}
+	}
+	return picked;
+}
 
 function detectProvider(url: string): Provider {
 	if (url.startsWith("mysql://") || url.startsWith("mysql2://")) {
@@ -76,29 +161,101 @@ function buildConnectionConfig(
 		return { TimeZone: timezone };
 	}
 	if (provider === "mysql") {
-		// Normalise to MySQL's expected offset format ('+00:00') or named zone
 		const tz = timezone.toLowerCase() === "utc" ? "+00:00" : timezone;
 		return { time_zone: tz };
 	}
 	return undefined;
 }
 
-function pickPoolOptions(
-	source: SqlPoolOptions | undefined,
-): SqlPoolOptions | undefined {
-	if (!source) {
-		return undefined;
+function normalizeRegisterOptions(
+	options?: SqlModuleOptions | string,
+): SqlModuleOptions {
+	if (typeof options === "string") {
+		return { timezone: options };
+	}
+	if (!options) {
+		return {};
 	}
 
-	const pool: SqlPoolOptions = {};
-	if (source.max !== undefined) pool.max = source.max;
-	if (source.idleTimeout !== undefined) pool.idleTimeout = source.idleTimeout;
-	if (source.maxLifetime !== undefined) pool.maxLifetime = source.maxLifetime;
-	if (source.connectionTimeout !== undefined) {
-		pool.connectionTimeout = source.connectionTimeout;
+	return pickSqlModuleOptions(options as Record<string, unknown>);
+}
+
+function buildSqlClientOptions(
+	provider: Provider,
+	timezone: string,
+	options: SqlModuleOptions,
+): SqlClientInitOptions {
+	const { timezone: _timezone, connection: userConnection, ...rest } = options;
+	const driverConnectionConfig = buildConnectionConfig(provider, timezone);
+	const connection = {
+		...driverConnectionConfig,
+		...userConnection,
+	};
+
+	return {
+		...rest,
+		...(Object.keys(connection).length > 0 && { connection }),
+	};
+}
+
+function resolveConnectionUrl(connection: string | ConnectionOptions): string {
+	if (typeof connection === "string") {
+		return connection;
 	}
 
-	return Object.keys(pool).length > 0 ? pool : undefined;
+	return `${connection.provider}://${connection.username}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`;
+}
+
+function resolveProvider(connection: string | ConnectionOptions): Provider {
+	return typeof connection === "string"
+		? detectProvider(connection)
+		: connection.provider;
+}
+
+function resolveTimezone(
+	connection: string | ConnectionOptions,
+	options: SqlModuleOptions,
+): string {
+	if (options.timezone) {
+		return options.timezone;
+	}
+
+	if (typeof connection === "object" && connection.timezone) {
+		return connection.timezone;
+	}
+
+	return "UTC";
+}
+
+function resolveRegisterOptions(
+	connection: string | ConnectionOptions,
+	options?: SqlModuleOptions | string,
+): SqlModuleOptions {
+	const normalized = normalizeRegisterOptions(options);
+
+	if (typeof connection !== "object") {
+		return normalized;
+	}
+
+	assertOnlyAllowedKeys(
+		connection as Record<string, unknown>,
+		[...SQL_CONNECTION_DETAIL_KEYS, ...SQL_MODULE_OPTION_KEYS],
+	);
+
+	const {
+		host: _host,
+		port: _port,
+		username: _username,
+		password: _password,
+		database: _database,
+		provider: _provider,
+		...connectionSqlOptions
+	} = connection;
+
+	return {
+		...pickSqlModuleOptions(connectionSqlOptions as Record<string, unknown>),
+		...normalized,
+	};
 }
 
 function isConnectionClosedError(err: unknown): boolean {
@@ -257,51 +414,31 @@ export class SqlModule {
 	private static sqlInstance: SQL;
 	private static provider: Provider | undefined;
 
-	static register(connection: SqlConnectionOptions): typeof SqlModule;
-	static register(connection: string, timezone?: string): typeof SqlModule;
+	static register(connection: ConnectionOptions): typeof SqlModule;
 	static register(
 		connection: string,
-		options: SqlRegisterOptions,
+		options?: SqlModuleOptions | string,
 	): typeof SqlModule;
 	static register(
-		connection: string | SqlConnectionOptions,
-		second?: string | SqlRegisterOptions,
+		connection: string | ConnectionOptions,
+		options?: SqlModuleOptions | string,
 	) {
-		const url =
-			typeof connection === "string"
-				? connection
-				: `${connection.provider}://${connection.username}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`;
-
-		const provider =
-			typeof connection === "string"
-				? detectProvider(connection)
-				: connection.provider;
+		const resolvedOptions = resolveRegisterOptions(connection, options);
+		const url = resolveConnectionUrl(connection);
+		const provider = resolveProvider(connection);
+		const timezone = resolveTimezone(connection, resolvedOptions);
+		const sqlOptions = buildSqlClientOptions(
+			provider,
+			timezone,
+			resolvedOptions,
+		);
 
 		SqlModule.provider = provider;
 
-		let timezone = "UTC";
-		let poolOptions: SqlPoolOptions | undefined;
-
-		if (typeof connection === "string") {
-			if (typeof second === "string") {
-				timezone = second;
-			} else if (second) {
-				timezone = second.timezone ?? "UTC";
-				poolOptions = pickPoolOptions(second);
-			}
-		} else {
-			timezone = connection.timezone ?? "UTC";
-			poolOptions = pickPoolOptions(connection);
-		}
-
-		const connectionConfig = buildConnectionConfig(provider, timezone);
-		const pool = poolOptions ?? {};
-
 		SqlModule.sqlInstance = new SQL({
 			url,
-			...pool,
-			...(connectionConfig && { connection: connectionConfig }),
-		});
+			...sqlOptions,
+		} as SQL.Options);
 
 		return SqlModule;
 	}
@@ -337,10 +474,6 @@ function detectOperation(query: string): string {
 	return "QUERY";
 }
 
-/**
- * Strips parameter values from SQL for safe inclusion in telemetry.
- * Keeps the query structure readable without leaking user data.
- */
 function sanitizeSql(query: string): string {
 	return query
 		.replace(/'[^']*'/g, "'?'")

--- a/lib/database/sql-module.ts
+++ b/lib/database/sql-module.ts
@@ -9,22 +9,116 @@ import { DatabaseError } from "../errors";
 import { Injectable } from "../injectable";
 import { Module } from "../module";
 
-type ConnectionOptions = {
+type Provider = "postgresql" | "mysql" | "sqlite";
+
+type BunSqlPoolOptions = Pick<
+	SQL.PostgresOrMySQLOptions,
+	| "max"
+	| "maxLifetime"
+	| "connectionTimeout"
+	| "idleTimeout"
+	| "connection"
+	| "tls"
+	| "prepare"
+	| "bigint"
+	| "onconnect"
+	| "onclose"
+	| "path"
+>;
+
+type BunSqliteClientOptions = Pick<
+	SQL.SQLiteOptions,
+	"readonly" | "create" | "safeIntegers" | "strict"
+>;
+
+/** Options forwarded by Bunstone to the underlying Bun.SQL client. */
+export type BunSqlClientOptions = Partial<
+	BunSqlPoolOptions & BunSqliteClientOptions
+>;
+
+/**
+ * Options accepted by {@link SqlModule.register}.
+ * Only Bunstone-supported settings are allowed.
+ */
+export type SqlModuleOptions = BunSqlClientOptions & {
+	/**
+	 * Timezone used for date/time interpretation on the database connection.
+	 * Mapped to driver `connection` settings when not provided explicitly.
+	 * Defaults to `UTC`.
+	 */
+	timezone?: string;
+};
+
+export type SqlConnectionDetails = {
 	host: string;
 	port: number;
 	username: string;
 	password: string;
 	database: string;
-	provider: "postgresql" | "mysql" | "sqlite";
-	/**
-	 * Timezone used for date/time interpretation on the database connection.
-	 * Defaults to 'UTC' to ensure consistent, offset-free date handling.
-	 * Set to 'local' to use the process timezone, or any valid tz identifier.
-	 */
-	timezone?: string;
+	provider: Provider;
 };
 
-type Provider = "postgresql" | "mysql" | "sqlite";
+export type ConnectionOptions = SqlConnectionDetails & SqlModuleOptions;
+
+type SqlClientInitOptions = Omit<
+	SqlModuleOptions,
+	"url" | "filename" | "timezone"
+>;
+
+const SQL_MODULE_OPTION_KEYS = [
+	"timezone",
+	"max",
+	"maxLifetime",
+	"connectionTimeout",
+	"idleTimeout",
+	"connection",
+	"tls",
+	"prepare",
+	"bigint",
+	"onconnect",
+	"onclose",
+	"path",
+	"readonly",
+	"create",
+	"safeIntegers",
+	"strict",
+] as const satisfies readonly (keyof SqlModuleOptions)[];
+
+const SQL_CONNECTION_DETAIL_KEYS = [
+	"host",
+	"port",
+	"username",
+	"password",
+	"database",
+	"provider",
+] as const satisfies readonly (keyof SqlConnectionDetails)[];
+
+function assertOnlyAllowedKeys(
+	source: Record<string, unknown>,
+	allowedKeys: readonly string[],
+): void {
+	const invalidKeys = Object.keys(source).filter(
+		(key) => !allowedKeys.includes(key),
+	);
+
+	if (invalidKeys.length > 0) {
+		throw DatabaseError.invalidConfig(invalidKeys, allowedKeys);
+	}
+}
+
+function pickSqlModuleOptions(
+	source: Record<string, unknown>,
+): SqlModuleOptions {
+	assertOnlyAllowedKeys(source, SQL_MODULE_OPTION_KEYS);
+
+	const picked = {} as SqlModuleOptions;
+	for (const key of SQL_MODULE_OPTION_KEYS) {
+		if (key in source) {
+			(picked as Record<string, unknown>)[key] = source[key];
+		}
+	}
+	return picked;
+}
 
 function detectProvider(url: string): Provider {
 	if (url.startsWith("mysql://") || url.startsWith("mysql2://")) {
@@ -45,7 +139,7 @@ function detectProvider(url: string): Provider {
 function buildConnectionConfig(
 	provider: Provider,
 	timezone: string,
-): Record<string, string | boolean | number> | undefined {
+): NonNullable<SQL.PostgresOrMySQLOptions["connection"]> | undefined {
 	if (provider === "postgresql") {
 		return { TimeZone: timezone };
 	}
@@ -55,6 +149,97 @@ function buildConnectionConfig(
 		return { time_zone: tz };
 	}
 	return undefined;
+}
+
+function normalizeRegisterOptions(
+	options?: SqlModuleOptions | string,
+): SqlModuleOptions {
+	if (typeof options === "string") {
+		return { timezone: options };
+	}
+	if (!options) {
+		return {};
+	}
+
+	return pickSqlModuleOptions(options as Record<string, unknown>);
+}
+
+function buildSqlClientOptions(
+	provider: Provider,
+	timezone: string,
+	options: SqlModuleOptions,
+): SqlClientInitOptions {
+	const { timezone: _timezone, connection: userConnection, ...rest } = options;
+	const driverConnectionConfig = buildConnectionConfig(provider, timezone);
+	const connection = {
+		...driverConnectionConfig,
+		...userConnection,
+	};
+
+	return {
+		...rest,
+		...(Object.keys(connection).length > 0 && { connection }),
+	};
+}
+
+function resolveConnectionUrl(connection: string | ConnectionOptions): string {
+	if (typeof connection === "string") {
+		return connection;
+	}
+
+	return `${connection.provider}://${connection.username}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`;
+}
+
+function resolveProvider(connection: string | ConnectionOptions): Provider {
+	return typeof connection === "string"
+		? detectProvider(connection)
+		: connection.provider;
+}
+
+function resolveTimezone(
+	connection: string | ConnectionOptions,
+	options: SqlModuleOptions,
+): string {
+	if (options.timezone) {
+		return options.timezone;
+	}
+
+	if (typeof connection === "object" && connection.timezone) {
+		return connection.timezone;
+	}
+
+	return "UTC";
+}
+
+function resolveRegisterOptions(
+	connection: string | ConnectionOptions,
+	options?: SqlModuleOptions | string,
+): SqlModuleOptions {
+	const normalized = normalizeRegisterOptions(options);
+
+	if (typeof connection !== "object") {
+		return normalized;
+	}
+
+	assertOnlyAllowedKeys(
+		connection as Record<string, unknown>,
+		[...SQL_CONNECTION_DETAIL_KEYS, ...SQL_MODULE_OPTION_KEYS],
+	);
+
+	const {
+		host: _host,
+		port: _port,
+		username: _username,
+		password: _password,
+		database: _database,
+		provider: _provider,
+		...connectionSqlOptions
+	} = connection;
+
+	return {
+		...pickSqlModuleOptions(connectionSqlOptions as Record<string, unknown>),
+		...normalized,
+	};
 }
 
 @Injectable()
@@ -176,31 +361,30 @@ export class SqlModule {
 	private static provider: Provider | undefined;
 
 	static register(connection: ConnectionOptions): typeof SqlModule;
-	static register(connection: string, timezone?: string): typeof SqlModule;
-	static register(connection: string | ConnectionOptions, timezone?: string) {
-		const url =
-			typeof connection === "string"
-				? connection
-				: `${connection.provider}://${connection.username}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`;
-
-		const provider =
-			typeof connection === "string"
-				? detectProvider(connection)
-				: connection.provider;
+	static register(
+		connection: string,
+		options?: SqlModuleOptions | string,
+	): typeof SqlModule;
+	static register(
+		connection: string | ConnectionOptions,
+		options?: SqlModuleOptions | string,
+	) {
+		const resolvedOptions = resolveRegisterOptions(connection, options);
+		const url = resolveConnectionUrl(connection);
+		const provider = resolveProvider(connection);
+		const timezone = resolveTimezone(connection, resolvedOptions);
+		const sqlOptions = buildSqlClientOptions(
+			provider,
+			timezone,
+			resolvedOptions,
+		);
 
 		SqlModule.provider = provider;
 
-		const tz =
-			typeof connection === "string"
-				? (timezone ?? "UTC")
-				: (connection.timezone ?? "UTC");
-
-		const connectionConfig = buildConnectionConfig(provider, tz);
-
 		SqlModule.sqlInstance = new SQL({
 			url,
-			...(connectionConfig && { connection: connectionConfig }),
-		});
+			...sqlOptions,
+		} as SQL.Options);
 
 		return SqlModule;
 	}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -244,11 +244,12 @@ export class CqrsError extends BunstoneError {
  * Codes:
  * - `BNS-DB-001` – SQL instance not initialised
  * - `BNS-DB-002` – query / transaction execution failed
+ * - `BNS-DB-003` – invalid SqlModule configuration option
  */
 export class DatabaseError extends BunstoneError {
 	constructor(
 		message: string,
-		code: "BNS-DB-001" | "BNS-DB-002" = "BNS-DB-001",
+		code: "BNS-DB-001" | "BNS-DB-002" | "BNS-DB-003" = "BNS-DB-001",
 		suggestion?: string,
 		context?: Record<string, unknown>,
 		cause?: Error,
@@ -264,6 +265,18 @@ export class DatabaseError extends BunstoneError {
 				"Call SqlModule.register(connectionStringOrOptions) inside your root AppModule imports.",
 				"Example: @Module({ imports: [SqlModule.register('postgresql://user:pass@host/db')] })",
 			].join("\n  "),
+		);
+	}
+
+	static invalidConfig(
+		invalidKeys: string[],
+		allowedKeys: readonly string[],
+	): DatabaseError {
+		return new DatabaseError(
+			`Invalid SqlModule option(s): ${invalidKeys.join(", ")}.`,
+			"BNS-DB-003",
+			`Use only supported options: ${allowedKeys.join(", ")}.`,
+			{ invalidKeys, allowedKeys },
 		);
 	}
 }

--- a/tests/sql-module.test.ts
+++ b/tests/sql-module.test.ts
@@ -1,11 +1,13 @@
+import type { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
 import {
-	AppStartup,
-	CommandBus,
-	Injectable,
-	Module,
-	SqlModule,
-	SqlService,
+    AppStartup,
+    CommandBus,
+    DatabaseError,
+    Injectable,
+    Module,
+    SqlModule,
+    SqlService,
 } from "../index";
 import { CqrsModule } from "../lib/cqrs/cqrs-module";
 
@@ -388,5 +390,120 @@ describe("SqlModule & Global DI", () => {
 		expect(results[0].name).toBe("Item 1");
 		expect(results[1].name).toBe("Item 2");
 		expect(results[2].name).toBe("Item 3");
+	});
+
+	test("should accept pool options when registering with a connection string", async () => {
+		@Module({
+			imports: [
+				SqlModule.register("sqlite://:memory:", {
+					maxLifetime: 25200,
+					connectionTimeout: 30,
+					max: 10,
+				}),
+			],
+		})
+		class PoolOptionsSqlRootModule {}
+
+		await AppStartup.create(PoolOptionsSqlRootModule);
+
+		const sql = SqlModule.getSqlInstance() as SQL & {
+			options: Record<string, unknown>;
+		};
+
+		expect(sql.options.max).toBe(10);
+		expect(sql.options.maxLifetime).toBe(25200);
+		expect(sql.options.connectionTimeout).toBe(30);
+	});
+
+	test("should keep timezone string overload for backward compatibility", async () => {
+		@Module({
+			imports: [SqlModule.register("sqlite://:memory:", "UTC")],
+		})
+		class TimezoneStringSqlRootModule {}
+
+		await AppStartup.create(TimezoneStringSqlRootModule);
+
+		const sql = SqlModule.getSqlInstance();
+		expect(sql).toBeDefined();
+	});
+
+	test("should accept pool options when registering with connection object", async () => {
+		@Module({
+			imports: [
+				SqlModule.register({
+					provider: "sqlite",
+					host: "localhost",
+					port: 0,
+					username: "user",
+					password: "pass",
+					database: ":memory:",
+					max: 5,
+					idleTimeout: 15,
+				}),
+			],
+		})
+		class ObjectPoolOptionsSqlRootModule {}
+
+		await AppStartup.create(ObjectPoolOptionsSqlRootModule);
+
+		const sql = SqlModule.getSqlInstance() as SQL & {
+			options: Record<string, unknown>;
+		};
+
+		expect(sql.options.max).toBe(5);
+		expect(sql.options.idleTimeout).toBe(15);
+	});
+
+	test("should accept supported Bun SQL options such as prepare and bigint", async () => {
+		@Module({
+			imports: [
+				SqlModule.register("sqlite://:memory:", {
+					prepare: false,
+					bigint: true,
+					onconnect: () => {},
+				}),
+			],
+		})
+		class SupportedBunOptionsSqlRootModule {}
+
+		await AppStartup.create(SupportedBunOptionsSqlRootModule);
+
+		const sql = SqlModule.getSqlInstance() as SQL & {
+			options: Record<string, unknown>;
+		};
+
+		expect(sql.options.prepare).toBe(false);
+		expect(sql.options.bigint).toBe(true);
+		expect(typeof sql.options.onconnect).toBe("function");
+	});
+
+	test("should reject invalid options at runtime when using connection string", () => {
+		expect(() =>
+			SqlModule.register("sqlite://:memory:", {
+				foo: "bar",
+			} as never),
+		).toThrow(DatabaseError);
+
+		try {
+			SqlModule.register("sqlite://:memory:", { foo: "bar" } as never);
+		} catch (error) {
+			expect(error).toBeInstanceOf(DatabaseError);
+			expect((error as DatabaseError).code).toBe("BNS-DB-003");
+			expect((error as DatabaseError).message).toContain("foo");
+		}
+	});
+
+	test("should reject invalid options at runtime when using connection object", () => {
+		expect(() =>
+			SqlModule.register({
+				provider: "sqlite",
+				host: "localhost",
+				port: 0,
+				username: "user",
+				password: "pass",
+				database: ":memory:",
+				invalidOption: true,
+			} as never),
+		).toThrow(DatabaseError);
 	});
 });

--- a/tests/sql-module.test.ts
+++ b/tests/sql-module.test.ts
@@ -1,7 +1,9 @@
+import type { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
 import {
 	AppStartup,
 	CommandBus,
+	DatabaseError,
 	Injectable,
 	Module,
 	SqlModule,
@@ -28,7 +30,6 @@ describe("SqlModule & Global DI", () => {
 
 		await AppStartup.create(RootModule);
 
-		// Get the injectables map from the module metadata
 		const injectables: Map<any, any> = Reflect.getMetadata(
 			"dip:injectables",
 			FeatureModule,
@@ -76,19 +77,14 @@ describe("SqlModule & Global DI", () => {
 		await AppStartup.create(SqlRootModule);
 		const sqlService = new SqlService();
 
-		// Create table
 		await sqlService.query(
 			"CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)",
 		);
-
-		// Insert data using .query()
 		await sqlService.query("INSERT INTO users (name) VALUES (?)", ["Alice"]);
 
-		// Insert data using .sql tag
 		const name = "Bob";
 		await sqlService.query(`INSERT INTO users (name) VALUES (?)`, [name]);
 
-		// Select data
 		const users = await sqlService.query("SELECT * FROM users ORDER BY id ASC");
 
 		expect(users).toHaveLength(2);
@@ -135,7 +131,6 @@ describe("SqlModule & Global DI", () => {
 		await AppStartup.create(AdvancedSqlRootModule);
 		const sqlService = new SqlService();
 
-		// Table Setup
 		await sqlService.query(
 			"CREATE TABLE departments (id INTEGER PRIMARY KEY, name TEXT)",
 		);
@@ -143,7 +138,6 @@ describe("SqlModule & Global DI", () => {
 			"CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT, dept_id INTEGER)",
 		);
 
-		// Insert Data
 		await sqlService.query("INSERT INTO departments (name) VALUES (?)", [
 			"Engineering",
 		]);
@@ -164,7 +158,6 @@ describe("SqlModule & Global DI", () => {
 			["Mike", 2],
 		);
 
-		// Update
 		await sqlService.query("UPDATE employees SET name = ? WHERE name = ?", [
 			"John Doe",
 			"John",
@@ -175,7 +168,6 @@ describe("SqlModule & Global DI", () => {
 		);
 		expect(updated[0].name).toBe("John Doe");
 
-		// Join
 		const joined = await sqlService.query(
 			`
       SELECT e.name as employee, d.name as department 
@@ -189,12 +181,10 @@ describe("SqlModule & Global DI", () => {
 		expect(joined.some((r: any) => r.employee === "John Doe")).toBe(true);
 		expect(joined.some((r: any) => r.employee === "Jane")).toBe(true);
 
-		// Delete
 		await sqlService.query("DELETE FROM employees WHERE name = ?", ["Mike"]);
 		const remaining = await sqlService.query("SELECT * FROM employees");
 		expect(remaining).toHaveLength(2);
 
-		// Aggregate
 		const counts = await sqlService.query(
 			"SELECT COUNT(*) as total FROM departments",
 		);
@@ -219,27 +209,21 @@ describe("SqlModule & Global DI", () => {
 			["Apple", 1.5, "Banana", 0.5, "Cherry", 2.0, "Date", 3.0],
 		);
 
-		// IN operator
-		// Note: Standard SQLite parameter binding for IN (?) usually requires one ? per element
-		// or using the array support if the driver allows. Bun SQL supports arrays in some contexts.
-		// For raw .query strings, we might need to build the (?, ?) string if the driver doesn't auto-expand.
 		const inResults = await sqlService.query(
 			"SELECT * FROM products WHERE name IN (?, ?)",
 			["Apple", "Banana"],
 		);
 		expect(inResults).toHaveLength(2);
 
-		// LIKE operator
 		const likeResults = await sqlService.query(
 			"SELECT * FROM products WHERE name LIKE ?",
-			["%a%"], // Apple, Banana, Date
+			["%a%"],
 		);
 		expect(likeResults).toHaveLength(3);
 
-		// BETWEEN operator
 		const betweenResults = await sqlService.query(
 			"SELECT * FROM products WHERE price BETWEEN ? AND ?",
-			[1.0, 2.5], // Apple (1.5), Cherry (2.0)
+			[1.0, 2.5],
 		);
 		expect(betweenResults).toHaveLength(2);
 		expect(betweenResults.some((p: any) => p.name === "Apple")).toBe(true);
@@ -271,7 +255,6 @@ describe("SqlModule & Global DI", () => {
 			[100.0, 1, 200.0, 1, 50.0, 2],
 		);
 
-		// Subquery in WHERE
 		const subqueryResults = await sqlService.query(
 			"SELECT name FROM customers WHERE id IN (SELECT customer_id FROM orders WHERE total > ?)",
 			[150.0],
@@ -279,7 +262,6 @@ describe("SqlModule & Global DI", () => {
 		expect(subqueryResults).toHaveLength(1);
 		expect(subqueryResults[0].name).toBe("Alice");
 
-		// CASE expression
 		const caseResults = await sqlService.query(
 			`SELECT total, 
        CASE WHEN total > 150 THEN 'High' 
@@ -353,7 +335,7 @@ describe("SqlModule & Global DI", () => {
 				},
 				{
 					query: "INSERT INTO products_tx (id, name) VALUES (?, ?)",
-					params: [1, "Product 1 Duplicate"], // Should fail due to PK violation
+					params: [1, "Product 1 Duplicate"],
 				},
 			]);
 		} catch (_e) {
@@ -390,46 +372,118 @@ describe("SqlModule & Global DI", () => {
 		expect(results[2].name).toBe("Item 3");
 	});
 
-	test("should accept pool options via connection string register", async () => {
+	test("should accept pool options when registering with a connection string", async () => {
 		@Module({
 			imports: [
 				SqlModule.register("sqlite://:memory:", {
-					timezone: "UTC",
-					max: 5,
-					idleTimeout: 3600,
-					maxLifetime: 7200,
-					connectionTimeout: 15,
+					maxLifetime: 25200,
+					connectionTimeout: 30,
+					max: 10,
 				}),
 			],
 		})
-		class PoolOptionsRootModule {}
+		class PoolOptionsSqlRootModule {}
 
-		await AppStartup.create(PoolOptionsRootModule);
-		const sqlService = new SqlService();
+		await AppStartup.create(PoolOptionsSqlRootModule);
 
-		const rows = await sqlService.query("SELECT 1 as ok");
-		expect(rows[0].ok).toBe(1);
+		const sql = SqlModule.getSqlInstance() as SQL & {
+			options: Record<string, unknown>;
+		};
+
+		expect(sql.options.max).toBe(10);
+		expect(sql.options.maxLifetime).toBe(25200);
+		expect(sql.options.connectionTimeout).toBe(30);
 	});
 
-	test("should accept pool options via connection object register", async () => {
+	test("should keep timezone string overload for backward compatibility", async () => {
+		@Module({
+			imports: [SqlModule.register("sqlite://:memory:", "UTC")],
+		})
+		class TimezoneStringSqlRootModule {}
+
+		await AppStartup.create(TimezoneStringSqlRootModule);
+
+		const sql = SqlModule.getSqlInstance();
+		expect(sql).toBeDefined();
+	});
+
+	test("should accept pool options when registering with connection object", async () => {
 		@Module({
 			imports: [
 				SqlModule.register({
-					provider: "postgresql",
+					provider: "sqlite",
 					host: "localhost",
-					port: 5432,
+					port: 0,
 					username: "user",
 					password: "pass",
-					database: "test",
-					max: 3,
-					idleTimeout: 1800,
-					maxLifetime: 3600,
+					database: ":memory:",
+					max: 5,
+					idleTimeout: 15,
 				}),
 			],
 		})
-		class ObjectPoolOptionsRootModule {}
+		class ObjectPoolOptionsSqlRootModule {}
 
-		await AppStartup.create(ObjectPoolOptionsRootModule);
-		expect(SqlModule.getSqlInstance()).toBeDefined();
+		await AppStartup.create(ObjectPoolOptionsSqlRootModule);
+
+		const sql = SqlModule.getSqlInstance() as SQL & {
+			options: Record<string, unknown>;
+		};
+
+		expect(sql.options.max).toBe(5);
+		expect(sql.options.idleTimeout).toBe(15);
+	});
+
+	test("should accept supported Bun SQL options such as prepare and bigint", async () => {
+		@Module({
+			imports: [
+				SqlModule.register("sqlite://:memory:", {
+					prepare: false,
+					bigint: true,
+					onconnect: () => {},
+				}),
+			],
+		})
+		class SupportedBunOptionsSqlRootModule {}
+
+		await AppStartup.create(SupportedBunOptionsSqlRootModule);
+
+		const sql = SqlModule.getSqlInstance() as SQL & {
+			options: Record<string, unknown>;
+		};
+
+		expect(sql.options.prepare).toBe(false);
+		expect(sql.options.bigint).toBe(true);
+		expect(typeof sql.options.onconnect).toBe("function");
+	});
+
+	test("should reject invalid options at runtime when using connection string", () => {
+		expect(() =>
+			SqlModule.register("sqlite://:memory:", {
+				foo: "bar",
+			} as never),
+		).toThrow(DatabaseError);
+
+		try {
+			SqlModule.register("sqlite://:memory:", { foo: "bar" } as never);
+		} catch (error) {
+			expect(error).toBeInstanceOf(DatabaseError);
+			expect((error as DatabaseError).code).toBe("BNS-DB-003");
+			expect((error as DatabaseError).message).toContain("foo");
+		}
+	});
+
+	test("should reject invalid options at runtime when using connection object", () => {
+		expect(() =>
+			SqlModule.register({
+				provider: "sqlite",
+				host: "localhost",
+				port: 0,
+				username: "user",
+				password: "pass",
+				database: ":memory:",
+				invalidOption: true,
+			} as never),
+		).toThrow(DatabaseError);
 	});
 });


### PR DESCRIPTION
## Contexto

O `SqlModule.register()` aceitava apenas a connection string (ou objeto de conexão) e, opcionalmente, `timezone` como string. Não era possível configurar pool nem outras opções do `Bun.SQL` — como `max`, `maxLifetime`, `connectionTimeout` e `idleTimeout` — diretamente no registro do módulo.

## Implementação

- `SqlModule.register(url, options)` agora aceita um segundo argumento com opções suportadas do `Bun.SQL` (pool, TLS, callbacks, SQLite, etc.)
- As mesmas opções podem ser passadas no registro via objeto de conexão
- `SqlModule.register(url, "UTC")` continua funcionando
- Tipagem fechada via `SqlModuleOptions` — apenas opções da whitelist são aceitas
- Validação em runtime: opções inválidas lançam `DatabaseError` (`BNS-DB-003`)
- `timezone` é mapeado automaticamente para as configs do driver (PostgreSQL/MySQL)
- Tipos exportados: `SqlModuleOptions`, `ConnectionOptions`, `BunSqlClientOptions` (aliases antigos mantidos)
- Documentação atualizada em `docs/database-sql.md` e `docs/pt-BR/database-sql.md`
